### PR TITLE
feat/task-02-images

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,12 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'images.microcms-assets.io',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: '**.microcms-assets.io',
+        pathname: '/**',
       },
     ],
   },

--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -3,7 +3,7 @@ import { PrevNextPosts } from '@/components/prev-next-posts';
 import { RelatedPosts } from '@/components/related-posts';
 import { getBlogPost } from '@/lib/api';
 import { formatDate } from '@/lib/utils';
-import Image from 'next/image';
+import { FallbackImage } from '@/components/fallback-image';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
@@ -50,7 +50,7 @@ export default async function BlogPostPage(props: BlogPostPageProps) {
           <div className="container text-center">
             <div className="max-w-3xl mx-auto space-y-4">
               <div className="mb-10 max-w-[360px] mx-auto">
-                <Image
+                <FallbackImage
                   src={post.coverImage?.url || '/placeholder.svg'}
                   alt={`Cover image for ${post.title}`}
                   width={1200}

--- a/src/components/blog-card.tsx
+++ b/src/components/blog-card.tsx
@@ -2,7 +2,7 @@ import { Author } from '@/components/author';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { formatDate } from '@/lib/utils';
 import type { BlogPost } from '@/types';
-import Image from 'next/image';
+import { FallbackImage } from '@/components/fallback-image';
 import Link from 'next/link';
 import { BsArrowClockwise, BsCalendar2Check, BsTag } from 'react-icons/bs';
 
@@ -20,7 +20,7 @@ export function BlogCard({ post, priority = false }: BlogCardProps) {
     >
       <Card className="h-full overflow-hidden border-border/30 bg-card/60 hover:border-primary/50 focus-within:border-primary/50 transition-all duration-300 group-hover:scale-98 group-active:scale-95 group-focus-visible:ring-2 group-focus-visible:ring-primary group-focus-visible:ring-offset-2 shadow-sm py-0">
         <div className="relative w-full aspect-[8/5] overflow-hidden">
-          <Image
+          <FallbackImage
             src={post.coverImage.url || '/placeholder.svg'}
             alt=""
             aria-hidden="true"

--- a/src/components/fallback-image.tsx
+++ b/src/components/fallback-image.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import Image, { type ImageProps } from 'next/image';
+import { useEffect, useState } from 'react';
+
+type FallbackImageProps = Omit<ImageProps, 'src'> & {
+  src: ImageProps['src'];
+  fallbackSrc?: ImageProps['src'];
+};
+
+export function FallbackImage({ src, fallbackSrc = '/placeholder.svg', alt, onError, ...rest }: FallbackImageProps) {
+  const [currentSrc, setCurrentSrc] = useState(src);
+
+  useEffect(() => {
+    setCurrentSrc(src);
+  }, [src]);
+
+  return (
+    <Image
+      {...rest}
+      alt={alt}
+      src={currentSrc}
+      onError={(event) => {
+        if (currentSrc !== fallbackSrc) {
+          setCurrentSrc(fallbackSrc);
+        }
+        onError?.(event);
+      }}
+    />
+  );
+}

--- a/src/components/fallback-image.tsx
+++ b/src/components/fallback-image.tsx
@@ -10,9 +10,11 @@ type FallbackImageProps = Omit<ImageProps, 'src'> & {
 
 export function FallbackImage({ src, fallbackSrc = '/placeholder.svg', alt, onError, ...rest }: FallbackImageProps) {
   const [currentSrc, setCurrentSrc] = useState(src);
+  const [hasTriedFallback, setHasTriedFallback] = useState(false);
 
   useEffect(() => {
     setCurrentSrc(src);
+    setHasTriedFallback(false);
   }, [src]);
 
   return (
@@ -21,8 +23,9 @@ export function FallbackImage({ src, fallbackSrc = '/placeholder.svg', alt, onEr
       alt={alt}
       src={currentSrc}
       onError={(event) => {
-        if (currentSrc !== fallbackSrc) {
+        if (!hasTriedFallback && currentSrc !== fallbackSrc) {
           setCurrentSrc(fallbackSrc);
+          setHasTriedFallback(true);
         }
         onError?.(event);
       }}

--- a/src/components/related-post-card.tsx
+++ b/src/components/related-post-card.tsx
@@ -4,7 +4,7 @@ import { Author } from '@/components/author';
 import { Card } from '@/components/ui/card';
 import { formatDate } from '@/lib/utils';
 import type { BlogPost } from '@/types';
-import Image from 'next/image';
+import { FallbackImage } from '@/components/fallback-image';
 import Link from 'next/link';
 import React from 'react';
 import { BsArrowClockwise, BsCalendar2Check, BsTag } from 'react-icons/bs';
@@ -24,7 +24,7 @@ export const RelatedPostCard = React.memo(function RelatedPostCard({ post }: Rel
         <div className="flex flex-col sm:flex-row">
           <div className="relative w-full sm:w-[330px] overflow-hidden">
             <div className="aspect-[8/5] w-full">
-              <Image
+              <FallbackImage
                 src={post.coverImage.url || '/placeholder.svg'}
                 alt=""
                 aria-hidden="true"


### PR DESCRIPTION
このプルリクエストでは、ブログアプリケーション全体で画像読み込みエラーを適切に処理するための再利用可能な`FallbackImage`コンポーネントを導入します。主要なコンポーネント数か所で`next/image`の直接使用を`FallbackImage`に置き換え、メイン画像の読み込みに失敗した場合にプレースホルダー画像が表示されるようにします。さらに、ワイルドカードサブドメインからの画像許可のため、画像ドメイン設定を更新しました。

**画像処理の改善点:**
* `src/components/fallback-image.tsx` に新しい `FallbackImage` コンポーネントを追加。`next/image` をラップし、元の画像の読み込みに失敗した場合に自動的にプレースホルダー画像にフォールバックします。
* `BlogPostPage`（`src/app/blog/[id]/page.tsx`）、`BlogCard`（`src/components/blog-card.tsx`）、`RelatedPostCard`（`src/components/related-post-card.tsx`）において、`next/image`の直接使用を`FallbackImage`に置き換え、一貫したフォールバック動作を実現。([src/app/blog/[id]/page.tsxL6-R6]

**設定更新:**
* `next.config.ts`の画像ドメイン設定を更新し、`microcms-assets.io`の任意のサブドメインからの画像読み込みを許可。様々な画像ソースとの互換性を向上。