### PR TITLE
fix/task-01-env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,10 @@
 # Required
-NEXT_PUBLIC_BASE_URL=http://localhost:3000
 MICROCMS_SERVICE_DOMAIN=your-service-domain
 MICROCMS_API_KEY=your-microcms-api-key
-REVALIDATE_SECRET=replace-with-secure-secret
 
 # Optional
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+REVALIDATE_SECRET=replace-with-secure-secret
 RESEND_API_KEY=
 CONTACT_TO=
 TURNSTILE_SECRET_KEY=

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,35 +1,35 @@
 import { z } from 'zod';
 
 type RawEnv = {
-  NEXT_PUBLIC_BASE_URL: string | undefined;
+  // NEXT_PUBLIC_BASE_URL: string | undefined;
   MICROCMS_SERVICE_DOMAIN: string | undefined;
   MICROCMS_API_KEY: string | undefined;
-  REVALIDATE_SECRET: string | undefined;
-  RESEND_API_KEY: string | undefined;
-  CONTACT_TO: string | undefined;
-  TURNSTILE_SECRET_KEY: string | undefined;
+  // REVALIDATE_SECRET: string | undefined;
+  // RESEND_API_KEY: string | undefined;
+  // CONTACT_TO: string | undefined;
+  // TURNSTILE_SECRET_KEY: string | undefined;
 };
 
 const EnvSchema = z.object({
-  NEXT_PUBLIC_BASE_URL: z
-    .string({ required_error: 'NEXT_PUBLIC_BASE_URL is required' })
-    .url('NEXT_PUBLIC_BASE_URL must be a valid URL'),
+  // NEXT_PUBLIC_BASE_URL: z
+  //   .string({ required_error: 'NEXT_PUBLIC_BASE_URL is required' })
+  //   .url('NEXT_PUBLIC_BASE_URL must be a valid URL'),
   MICROCMS_SERVICE_DOMAIN: z
     .string({ required_error: 'MICROCMS_SERVICE_DOMAIN is required' })
     .min(1, 'MICROCMS_SERVICE_DOMAIN cannot be empty'),
   MICROCMS_API_KEY: z
     .string({ required_error: 'MICROCMS_API_KEY is required' })
     .min(1, 'MICROCMS_API_KEY cannot be empty'),
-  REVALIDATE_SECRET: z
-    .string({ required_error: 'REVALIDATE_SECRET is required' })
-    .min(10, 'REVALIDATE_SECRET must be at least 10 characters'),
-  // オプションのキーは未定義を受け入れるが、指定された場合に空白のみの値に対しては依然としてガードする。
-  RESEND_API_KEY: z.string().min(1, 'RESEND_API_KEY cannot be empty').optional(),
-  CONTACT_TO: z.string().email('CONTACT_TO must be a valid email').optional(),
-  TURNSTILE_SECRET_KEY: z
-    .string()
-    .min(1, 'TURNSTILE_SECRET_KEY cannot be empty')
-    .optional(),
+  // REVALIDATE_SECRET: z
+  //   .string({ required_error: 'REVALIDATE_SECRET is required' })
+  //   .min(10, 'REVALIDATE_SECRET must be at least 10 characters'),
+  // // オプションのキーは未定義を受け入れるが、指定された場合に空白のみの値に対しては依然としてガードする。
+  // RESEND_API_KEY: z.string().min(1, 'RESEND_API_KEY cannot be empty').optional(),
+  // CONTACT_TO: z.string().email('CONTACT_TO must be a valid email').optional(),
+  // TURNSTILE_SECRET_KEY: z
+  //   .string()
+  //   .min(1, 'TURNSTILE_SECRET_KEY cannot be empty')
+  //   .optional(),
 });
 
 // 環境変数の値をトリミングし、空白を未定義に折りたたむことで、オプションのスキーマフィールドがオプションのまま維持されるようにする。
@@ -40,13 +40,13 @@ const normalize = (value: string | undefined): string | undefined => {
 };
 
 const rawEnv: RawEnv = {
-  NEXT_PUBLIC_BASE_URL: normalize(process.env.NEXT_PUBLIC_BASE_URL),
+  // NEXT_PUBLIC_BASE_URL: normalize(process.env.NEXT_PUBLIC_BASE_URL),
   MICROCMS_SERVICE_DOMAIN: normalize(process.env.MICROCMS_SERVICE_DOMAIN),
   MICROCMS_API_KEY: normalize(process.env.MICROCMS_API_KEY),
-  REVALIDATE_SECRET: normalize(process.env.REVALIDATE_SECRET),
-  RESEND_API_KEY: normalize(process.env.RESEND_API_KEY),
-  CONTACT_TO: normalize(process.env.CONTACT_TO),
-  TURNSTILE_SECRET_KEY: normalize(process.env.TURNSTILE_SECRET_KEY),
+  // REVALIDATE_SECRET: normalize(process.env.REVALIDATE_SECRET),
+  // RESEND_API_KEY: normalize(process.env.RESEND_API_KEY),
+  // CONTACT_TO: normalize(process.env.CONTACT_TO),
+  // TURNSTILE_SECRET_KEY: normalize(process.env.TURNSTILE_SECRET_KEY),
 };
 
 const result = EnvSchema.safeParse(rawEnv);


### PR DESCRIPTION
This pull request updates environment variable handling by moving several variables from required to optional status. The main change is that only `MICROCMS_SERVICE_DOMAIN` and `MICROCMS_API_KEY` are now strictly required and validated; other environment variables are commented out in both the type definitions and schema validation, making them effectively optional and unvalidated by the codebase.

**Environment variable schema changes:**

* Commented out `NEXT_PUBLIC_BASE_URL`, `REVALIDATE_SECRET`, `RESEND_API_KEY`, `CONTACT_TO`, and `TURNSTILE_SECRET_KEY` from the `RawEnv` type and `EnvSchema` validation, so only `MICROCMS_SERVICE_DOMAIN` and `MICROCMS_API_KEY` remain required and validated.

* Updated the construction of the `rawEnv` object to comment out normalization for the now-optional variables, aligning with the new schema.

**Configuration file update:**

* Moved `NEXT_PUBLIC_BASE_URL` and `REVALIDATE_SECRET` from the "Required" section to the "Optional" section in `.env.example`, reflecting their new optional status.