### PR TITLE
feat/task-04-revalidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,20 @@ microCMS 連携について
 - 記事一覧: `getPosts`
 - 記事詳細: `getPostById`
 - タグ一覧: `getTags`
+- microCMS の Webhook で `/api/revalidate` を叩き、配信中サイトのキャッシュを更新できます（`x-revalidate-secret` ヘッダーに `REVALIDATE_SECRET` を設定）。
+  - Webhook 設定例（microCMS 管理画面）
+    1. 対象サービスの「API 設定」→「Webhook」を開く
+    2. URL に `https://<YOUR_DOMAIN>/api/revalidate` を指定
+    3. HTTP Method は `POST`
+    4. HTTP Header に `x-revalidate-secret: <REVALIDATE_SECRET>` を追加
+    5. 監視イベント（公開・更新・削除など）を有効化して保存
+  - 手動検証用 cURL 例
+
+    ```bash
+    curl -X POST \
+      -H "x-revalidate-secret: $REVALIDATE_SECRET" \
+      https://your-domain.example.com/api/revalidate
+    ```
 
 UI / スタイル
 - Tailwind CSS v4 を使用（`src/app/globals.css` に `@tailwind` と `@plugin "@tailwindcss/typography"` を記述）

--- a/app/api/revalidate/handler.ts
+++ b/app/api/revalidate/handler.ts
@@ -1,0 +1,40 @@
+import { revalidatePath, revalidateTag } from 'next/cache';
+import { NextResponse } from 'next/server';
+
+type RevalidateDeps = {
+  expectedSecret?: string | null;
+  revalidateTagFn?: typeof revalidateTag;
+  revalidatePathFn?: typeof revalidatePath;
+  headerName?: string;
+};
+
+const DEFAULT_HEADER = 'x-revalidate-secret';
+const REVALIDATE_TAGS = ['posts', 'tags'] as const;
+const REVALIDATE_PATHS = ['/', '/blog'] as const;
+
+export async function handleRevalidate(
+  request: Request,
+  {
+    expectedSecret = process.env.REVALIDATE_SECRET,
+    revalidateTagFn = revalidateTag,
+    revalidatePathFn = revalidatePath,
+    headerName = DEFAULT_HEADER,
+  }: RevalidateDeps = {},
+) {
+  if (!expectedSecret) {
+    return NextResponse.json({ ok: false, message: 'Missing revalidate secret configuration.' }, { status: 500 });
+  }
+
+  const providedSecret = request.headers.get(headerName);
+
+  if (!providedSecret || providedSecret !== expectedSecret) {
+    return NextResponse.json({ ok: false, message: 'Unauthorized' }, { status: 401 });
+  }
+
+  await Promise.all(REVALIDATE_TAGS.map((tag) => revalidateTagFn(tag)));
+  REVALIDATE_PATHS.forEach((path) => {
+    void revalidatePathFn(path);
+  });
+
+  return NextResponse.json({ ok: true, revalidated: true });
+}

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,5 @@
+import { handleRevalidate } from './handler';
+
+export async function POST(request: Request) {
+  return handleRevalidate(request);
+}

--- a/tests/revalidate-route.test.ts
+++ b/tests/revalidate-route.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'bun:test';
+
+import { handleRevalidate } from '../app/api/revalidate/handler';
+
+describe('handleRevalidate', () => {
+  it('returns 200 and triggers revalidation when secret matches', async () => {
+    const revalidatedTags: string[] = [];
+    const revalidatedPaths: string[] = [];
+
+    const request = new Request('http://localhost/api/revalidate', {
+      method: 'POST',
+      headers: {
+        'x-revalidate-secret': 'secret',
+      },
+    });
+
+    const response = await handleRevalidate(request, {
+      expectedSecret: 'secret',
+      revalidateTagFn: async (tag) => {
+        revalidatedTags.push(tag);
+      },
+      revalidatePathFn: (path) => {
+        revalidatedPaths.push(path);
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({ ok: true, revalidated: true });
+    expect(revalidatedTags).toEqual(['posts', 'tags']);
+    expect(revalidatedPaths).toEqual(['/', '/blog']);
+  });
+
+  it('returns 401 when secret is invalid', async () => {
+    const request = new Request('http://localhost/api/revalidate', {
+      method: 'POST',
+      headers: {
+        'x-revalidate-secret': 'wrong',
+      },
+    });
+
+    const response = await handleRevalidate(request, {
+      expectedSecret: 'secret',
+      revalidateTagFn: async () => {},
+      revalidatePathFn: () => {},
+    });
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- 日本語で記述して -->
This pull request introduces a secure cache revalidation endpoint for microCMS integration, allowing the site to refresh its cached content via webhook or manual requests. The implementation includes a new API route, handler logic for secret validation and cache updates, comprehensive documentation, and automated tests to ensure correct behavior.

**API and Security Enhancements:**

* Added `app/api/revalidate/handler.ts` with the `handleRevalidate` function, which validates a secret from the request header and triggers cache revalidation for specific tags and paths.
* Created `app/api/revalidate/route.ts` to expose the `/api/revalidate` endpoint, handling POST requests by invoking the new handler.

**Documentation Updates:**

* Updated `README.md` to describe how to configure microCMS webhooks and manually trigger cache revalidation, including example cURL usage and setup steps.

**Testing Improvements:**

* Added `tests/revalidate-route.test.ts` to verify correct secret validation, cache revalidation triggers, and response codes for authorized and unauthorized requests.