### PR TITLE
feat/task-05-seo

### DIFF
--- a/src/app/blog/[slug]/opengraph-image.tsx
+++ b/src/app/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,91 @@
+import { getPostBySlug } from '@/lib/cms';
+import { ImageResponse } from 'next/og';
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export const runtime = 'edge';
+
+const backgroundGradient = 'linear-gradient(135deg, #1e293b, #6366f1)';
+
+export default async function Image({ params }: { params: { slug: string } }) {
+  try {
+    const post = await getPostBySlug(params.slug);
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            background: backgroundGradient,
+            width: '100%',
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            padding: '72px',
+            color: 'white',
+            fontFamily: 'Inter, Noto Sans JP, sans-serif',
+          }}
+        >
+          <span style={{ fontSize: 36, opacity: 0.7 }}>rymlab</span>
+          <h1
+            style={{
+              marginTop: 24,
+              fontSize: 72,
+              fontWeight: 700,
+              lineHeight: 1.1,
+              maxWidth: '85%',
+            }}
+          >
+            {post.title}
+          </h1>
+          {post.excerpt ? (
+            <p
+              style={{
+                marginTop: 24,
+                fontSize: 30,
+                maxWidth: '75%',
+                opacity: 0.85,
+                lineHeight: 1.4,
+              }}
+            >
+              {post.excerpt}
+            </p>
+          ) : null}
+        </div>
+      ),
+      {
+        ...size,
+      },
+    );
+  } catch (error) {
+    console.error('Failed to generate OG image:', error);
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            background: backgroundGradient,
+            width: '100%',
+            height: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: 'white',
+            fontFamily: 'Inter, Noto Sans JP, sans-serif',
+            fontSize: 64,
+          }}
+        >
+          rymlab
+        </div>
+      ),
+      {
+        ...size,
+      },
+    );
+  }
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,7 +1,8 @@
 import { Author } from '@/components/author';
 import { PrevNextPosts } from '@/components/prev-next-posts';
 import { RelatedPosts } from '@/components/related-posts';
-import { getPostById } from '@/lib/cms';
+import { getPostBySlug } from '@/lib/cms';
+import { buildBlogPostingJsonLd, buildBreadcrumbJsonLd, getSiteUrl, serializeJsonLd } from '@/lib/seo';
 import { formatDate } from '@/lib/utils';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -11,14 +12,16 @@ import { BsArrowClockwise, BsCalendar2Check, BsTag } from 'react-icons/bs';
 
 interface BlogPostPageProps {
   params: Promise<{
-    id: string;
+    slug: string;
   }>;
 }
 
 export async function generateMetadata(props: BlogPostPageProps) {
   const params = await props.params;
   try {
-    const post = await getPostById(params.id);
+    const post = await getPostBySlug(params.slug);
+    const siteUrl = getSiteUrl();
+    const canonicalUrl = new URL(`/blog/${post.slug}`, siteUrl).toString();
 
     return {
       title: post.title,
@@ -26,7 +29,17 @@ export async function generateMetadata(props: BlogPostPageProps) {
       openGraph: {
         title: post.title,
         description: post.excerpt,
+        url: canonicalUrl,
+        type: 'article',
         images: [{ url: post.coverImage.url }],
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: post.title,
+        description: post.excerpt,
+      },
+      alternates: {
+        canonical: canonicalUrl,
       },
     };
   } catch {
@@ -42,7 +55,17 @@ export async function generateMetadata(props: BlogPostPageProps) {
 export default async function BlogPostPage(props: BlogPostPageProps) {
   const params = await props.params;
   try {
-    const post = await getPostById(params.id);
+    const post = await getPostBySlug(params.slug);
+    const siteUrl = getSiteUrl();
+    const canonicalUrl = new URL(`/blog/${post.slug}`, siteUrl).toString();
+    const breadcrumbJsonLd = serializeJsonLd(
+      buildBreadcrumbJsonLd([
+        { name: 'Home', url: siteUrl },
+        { name: 'Blog', url: `${siteUrl}/blog` },
+        { name: post.title, url: canonicalUrl },
+      ]),
+    );
+    const blogPostingJsonLd = serializeJsonLd(buildBlogPostingJsonLd(post));
 
     return (
       <>
@@ -121,9 +144,19 @@ export default async function BlogPostPage(props: BlogPostPageProps) {
           </Suspense>
 
           <Suspense fallback={<div className="py-8 text-center">Loading navigation...</div>}>
-            <PrevNextPosts postId={params.id} />
+            <PrevNextPosts postSlug={post.slug} />
           </Suspense>
         </article>
+        <script
+          type="application/ld+json"
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: breadcrumbJsonLd }}
+        />
+        <script
+          type="application/ld+json"
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: blogPostingJsonLd }}
+        />
       </>
     );
   } catch (error) {

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -3,7 +3,32 @@ import { PageHero } from '@/components/page-hero';
 import { SearchForm } from '@/components/search-form';
 import { SectionContainer } from '@/components/section-container';
 import { TagsList } from '@/components/tags-list';
+import { getSiteDescription, getSiteName, getSiteUrl } from '@/lib/seo';
+import type { Metadata } from 'next';
 import { Suspense } from 'react';
+
+const siteName = getSiteName();
+const siteDescription = getSiteDescription();
+const siteUrl = getSiteUrl();
+
+export const metadata: Metadata = {
+  title: 'Blog',
+  description: siteDescription,
+  alternates: {
+    canonical: '/blog',
+  },
+  openGraph: {
+    title: `${siteName} Blog`,
+    description: siteDescription,
+    url: `${siteUrl}/blog`,
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: `${siteName} Blog`,
+    description: siteDescription,
+  },
+};
 
 interface BlogPageProps {
   searchParams: Promise<{

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,0 +1,43 @@
+import { getPosts } from '@/lib/cms';
+import { getSiteDescription, getSiteName, getSiteUrl } from '@/lib/seo';
+import { Feed } from 'feed';
+
+export async function GET() {
+  const siteUrl = getSiteUrl();
+  const siteName = getSiteName();
+  const siteDescription = getSiteDescription();
+
+  const feed = new Feed({
+    id: siteUrl,
+    link: siteUrl,
+    title: siteName,
+    description: siteDescription,
+    language: 'ja',
+    favicon: `${siteUrl}/favicon.ico`,
+    updated: new Date(),
+    copyright: `${new Date().getFullYear()} ${siteName}`,
+  });
+
+  try {
+    const { items: posts } = await getPosts({ limit: 20 });
+    posts.forEach((post) => {
+      const postUrl = `${siteUrl}/blog/${post.slug}`;
+      feed.addItem({
+        title: post.title,
+        id: postUrl,
+        link: postUrl,
+        description: post.excerpt,
+        content: post.content,
+        date: new Date(post.updatedAt ?? post.publishedAt),
+      });
+    });
+  } catch (error) {
+    console.error('Failed to build RSS feed:', error);
+  }
+
+  return new Response(feed.rss2(), {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+    },
+  });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import Footer from '@/components/footer';
 import Header from '@/components/header';
 import { ThemeProvider } from '@/components/theme-provider';
+import { buildWebSiteJsonLd, getSiteDescription, getSiteName, getSiteUrl, serializeJsonLd } from '@/lib/seo';
 import { cn } from '@/lib/utils';
 import type { Metadata } from 'next';
 import { Inter, Noto_Sans_JP } from 'next/font/google';
@@ -22,14 +23,39 @@ const fontUi = Inter({
   subsets: ['latin'],
 });
 
+const SITE_NAME = getSiteName();
+const SITE_DESCRIPTION = getSiteDescription();
+const SITE_URL = getSiteUrl();
+
 export const metadata: Metadata = {
-  title: 'rymlab',
-  description:
-    'A modern tech blog for sharing knowledge and insights on web development, programming, and technology and quality assurance.',
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: SITE_NAME,
+    template: `%s | ${SITE_NAME}`,
+  },
+  description: SITE_DESCRIPTION,
   keywords: ['rymlab', 'web development', 'programming', 'technology', 'quality assurance'],
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    title: SITE_NAME,
+    description: SITE_DESCRIPTION,
+    url: SITE_URL,
+    siteName: SITE_NAME,
+    locale: 'ja_JP',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: SITE_NAME,
+    description: SITE_DESCRIPTION,
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const webSiteJsonLd = serializeJsonLd(buildWebSiteJsonLd());
+
   return (
     <html lang="ja" suppressHydrationWarning>
       <head>
@@ -42,6 +68,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           fontUi.variable,
         )}
       >
+        <script
+          type="application/ld+json"
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: webSiteJsonLd }}
+        />
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <div className="flex min-h-screen flex-col">
             <a href="#main-content" className="skip-link">

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,69 @@
+import { getSiteDescription, getSiteName } from '@/lib/seo';
+import { ImageResponse } from 'next/og';
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export const runtime = 'edge';
+
+const backgroundGradient = 'linear-gradient(135deg, #0f172a, #2563eb)';
+
+export default function Image() {
+  const siteName = getSiteName();
+  const siteDescription = getSiteDescription();
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: backgroundGradient,
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'flex-start',
+          padding: '80px',
+          color: 'white',
+          fontFamily: 'Inter, Noto Sans JP, sans-serif',
+        }}
+      >
+        <span
+          style={{
+            fontSize: 42,
+            opacity: 0.7,
+          }}
+        >
+          {siteName}
+        </span>
+        <h1
+          style={{
+            marginTop: 16,
+            fontSize: 82,
+            fontWeight: 700,
+            lineHeight: 1.1,
+          }}
+        >
+          Inspiring stories for modern developers
+        </h1>
+        <p
+          style={{
+            marginTop: 24,
+            fontSize: 32,
+            maxWidth: '70%',
+            lineHeight: 1.3,
+          }}
+        >
+          {siteDescription}
+        </p>
+      </div>
+    ),
+    {
+      ...size,
+    },
+  );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,12 @@
+import { getSiteUrl } from '@/lib/seo';
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  const siteUrl = getSiteUrl();
+
+  return {
+    rules: [{ userAgent: '*', allow: '/' }],
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,43 @@
+import { getAllPostSlugs } from '@/lib/cms';
+import { getSiteUrl } from '@/lib/seo';
+import type { MetadataRoute } from 'next';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const siteUrl = getSiteUrl();
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: `${siteUrl}/`,
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${siteUrl}/blog`,
+      changeFrequency: 'daily',
+      priority: 0.9,
+    },
+    {
+      url: `${siteUrl}/about`,
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    },
+    {
+      url: `${siteUrl}/contact`,
+      changeFrequency: 'monthly',
+      priority: 0.4,
+    },
+  ];
+
+  try {
+    const slugs = await getAllPostSlugs();
+    const postEntries: MetadataRoute.Sitemap = slugs.map((slug) => ({
+      url: `${siteUrl}/blog/${slug}`,
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    }));
+
+    return [...staticRoutes, ...postEntries];
+  } catch (error) {
+    console.error('Failed to generate sitemap:', error);
+    return staticRoutes;
+  }
+}

--- a/src/components/blog-card.tsx
+++ b/src/components/blog-card.tsx
@@ -14,9 +14,9 @@ interface BlogCardProps {
 export function BlogCard({ post, priority = false }: BlogCardProps) {
   return (
     <Link
-      href={`/blog/${post.id}`}
+      href={`/blog/${post.slug}`}
       className="group block focus-visible:outline-none h-full"
-      aria-labelledby={`blog-title-${post.id}`}
+      aria-labelledby={`blog-title-${post.slug}`}
     >
       <Card className="h-full overflow-hidden border-border/30 bg-card/60 hover:border-primary/50 focus-within:border-primary/50 transition-all duration-300 group-hover:scale-98 group-active:scale-95 group-focus-visible:ring-2 group-focus-visible:ring-primary group-focus-visible:ring-offset-2 shadow-sm py-0">
         <div className="relative w-full aspect-[8/5] overflow-hidden">
@@ -32,7 +32,7 @@ export function BlogCard({ post, priority = false }: BlogCardProps) {
         </div>
         <CardContent className="p-4 space-y-3">
           <h3
-            id={`blog-title-${post.id}`}
+            id={`blog-title-${post.slug}`}
             className="card-title group-hover:text-primary transition-colors line-clamp-2"
           >
             {post.title}

--- a/src/components/blog-posts-list.tsx
+++ b/src/components/blog-posts-list.tsx
@@ -43,7 +43,7 @@ export async function BlogPostsList({ searchParams }: { searchParams: SearchPara
     <>
       <div className="grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-6">
         {posts.map((post, index) => (
-          <BlogCard key={post.id} post={post} priority={index < 2} />
+          <BlogCard key={post.slug} post={post} priority={index < 2} />
         ))}
       </div>
       {totalPages > 1 && (

--- a/src/components/latest-posts.tsx
+++ b/src/components/latest-posts.tsx
@@ -23,7 +23,7 @@ export async function LatestPosts() {
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-6 sm:gap-8">
       {latestPosts.map((post, index) => (
-        <BlogCard key={post.id} post={post} priority={index === 0} />
+        <BlogCard key={post.slug} post={post} priority={index === 0} />
       ))}
     </div>
   );

--- a/src/components/prev-next-posts.tsx
+++ b/src/components/prev-next-posts.tsx
@@ -3,15 +3,18 @@ import { getPosts } from '@/lib/cms';
 import type { BlogPost } from '@/types';
 import { BsArrowLeft, BsArrowRight } from 'react-icons/bs';
 
-export async function PrevNextPosts({ postId }: { postId: string }) {
+export async function PrevNextPosts({ postSlug }: { postSlug: string }) {
   let prevPost: BlogPost | null = null;
   let nextPost: BlogPost | null = null;
 
   try {
     const { items: allPosts } = await getPosts({ limit: 100 });
-    const currentIndex = allPosts.findIndex((p) => p.id === postId);
-    prevPost = currentIndex < allPosts.length - 1 ? allPosts[currentIndex + 1] : null;
-    nextPost = currentIndex > 0 ? allPosts[currentIndex - 1] : null;
+    const currentIndex = allPosts.findIndex((p) => p.slug === postSlug);
+
+    if (currentIndex !== -1) {
+      prevPost = currentIndex < allPosts.length - 1 ? allPosts[currentIndex + 1] : null;
+      nextPost = currentIndex > 0 ? allPosts[currentIndex - 1] : null;
+    }
   } catch (error) {
     console.error('Error fetching related posts:', error);
   }

--- a/src/components/related-post-card.tsx
+++ b/src/components/related-post-card.tsx
@@ -16,9 +16,9 @@ interface RelatedPostCardProps {
 export const RelatedPostCard = React.memo(function RelatedPostCard({ post }: RelatedPostCardProps) {
   return (
     <Link
-      href={`/blog/${post.id}`}
+      href={`/blog/${post.slug}`}
       className="group block max-w-[830px] mx-auto w-full focus-visible:outline-none"
-      aria-labelledby={`related-title-${post.id}`}
+      aria-labelledby={`related-title-${post.slug}`}
     >
       <Card className="h-full overflow-hidden border-border/30 bg-card/60 hover:border-primary/50 focus-within:border-primary/50 transition-all duration-300 group-hover:scale-98 group-active:scale-95 group-focus-visible:ring-2 group-focus-visible:ring-primary group-focus-visible:ring-offset-2 shadow-sm py-0">
         <div className="flex flex-col sm:flex-row">
@@ -38,7 +38,7 @@ export const RelatedPostCard = React.memo(function RelatedPostCard({ post }: Rel
           <div className="p-4 sm:p-5 flex flex-col justify-between sm:flex-1">
             <div>
               <h3
-                id={`related-title-${post.id}`}
+                id={`related-title-${post.slug}`}
                 className="card-title group-hover:text-primary transition-colors line-clamp-2 mb-2"
               >
                 {post.title}

--- a/src/components/related-posts.tsx
+++ b/src/components/related-posts.tsx
@@ -17,7 +17,7 @@ export async function RelatedPosts({ relatedPosts }: { relatedPosts: BlogPost[] 
       </h2>
       <div className="flex flex-col gap-4">
         {relatedPosts.map((relatedPost) => (
-          <RelatedPostCard key={relatedPost.id} post={relatedPost} />
+          <RelatedPostCard key={relatedPost.slug} post={relatedPost} />
         ))}
       </div>
     </section>

--- a/src/lib/cms.ts
+++ b/src/lib/cms.ts
@@ -4,9 +4,7 @@ import { ENV } from './env';
 import {
   PostListSchema,
   TagListSchema,
-  PostSchema,
   SlugListSchema,
-  type CMSPost,
   type CMSPostList,
   type CMSSlugList,
   type CMSTagList,
@@ -104,17 +102,6 @@ export async function getPostBySlug(slug: string): Promise<BlogPost> {
   }
 
   return post;
-}
-
-export async function getPostById(id: string): Promise<BlogPost> {
-  const post = await fetchFromCMS<CMSPost>(
-    `blogs/${id}`,
-    { depth: 3 },
-    { revalidate: DEFAULT_REVALIDATE, tags: ['posts'] },
-    PostSchema.parse,
-  );
-
-  return adaptBlog(post);
 }
 
 export async function getAllPostSlugs(): Promise<string[]> {

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,88 @@
+import type { BlogPost } from '@/types';
+
+const DEFAULT_SITE_NAME = 'rymlab';
+const DEFAULT_SITE_DESCRIPTION =
+  'A modern tech blog for sharing knowledge and insights on web development, programming, technology, and quality assurance.';
+
+function resolveSiteUrl() {
+  const raw = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
+  return raw.replace(/\/$/, '');
+}
+
+export function getSiteName() {
+  return process.env.NEXT_PUBLIC_SITE_NAME || DEFAULT_SITE_NAME;
+}
+
+export function getSiteDescription() {
+  return process.env.NEXT_PUBLIC_SITE_DESCRIPTION || DEFAULT_SITE_DESCRIPTION;
+}
+
+export function getSiteUrl() {
+  return resolveSiteUrl();
+}
+
+export function buildWebSiteJsonLd() {
+  const siteUrl = getSiteUrl();
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: getSiteName(),
+    url: siteUrl,
+    description: getSiteDescription(),
+    potentialAction: {
+      '@type': 'SearchAction',
+      target: `${siteUrl}/blog?q={search_term_string}`,
+      'query-input': 'required name=search_term_string',
+    },
+  };
+}
+
+export function buildBreadcrumbJsonLd(items: { name: string; url: string }[]) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+}
+
+export function buildBlogPostingJsonLd(post: BlogPost) {
+  const siteUrl = getSiteUrl();
+  const canonicalUrl = new URL(`/blog/${post.slug}`, siteUrl).toString();
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: post.title,
+    description: post.excerpt,
+    image: post.coverImage?.url ? [post.coverImage.url] : undefined,
+    datePublished: post.publishedAt,
+    dateModified: post.updatedAt ?? post.publishedAt,
+    author: {
+      '@type': 'Person',
+      name: post.author?.name ?? 'Unknown Author',
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: getSiteName(),
+      logo: {
+        '@type': 'ImageObject',
+        url: new URL('/favicon.ico', siteUrl).toString(),
+      },
+    },
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': canonicalUrl,
+    },
+    url: canonicalUrl,
+  };
+}
+
+export function serializeJsonLd(data: unknown) {
+  return JSON.stringify(data);
+}

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+
+import { buildBlogPostingJsonLd, buildBreadcrumbJsonLd, buildWebSiteJsonLd, serializeJsonLd } from '../src/lib/seo';
+
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+describe('seo helpers', () => {
+  it('builds WebSite JSON-LD using environment configuration', () => {
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://example.com';
+    process.env.NEXT_PUBLIC_SITE_NAME = 'Example';
+    process.env.NEXT_PUBLIC_SITE_DESCRIPTION = 'Example description';
+
+    const jsonLd = buildWebSiteJsonLd();
+
+    expect(jsonLd['@type']).toBe('WebSite');
+    expect(jsonLd.name).toBe('Example');
+    expect(jsonLd.url).toBe('https://example.com');
+    expect(jsonLd.potentialAction.target).toBe('https://example.com/blog?q={search_term_string}');
+  });
+
+  it('builds BlogPosting JSON-LD with canonical URL', () => {
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://example.com';
+    const jsonLd = buildBlogPostingJsonLd({
+      id: 'post-id',
+      title: 'My Post',
+      slug: 'my-post',
+      excerpt: 'Summary',
+      publishedAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-02T00:00:00.000Z',
+      coverImage: {
+        url: 'https://example.com/cover.jpg',
+        width: 1200,
+        height: 630,
+      },
+      author: {
+        id: 'author-id',
+        name: 'Author',
+        image: {
+          url: 'https://example.com/avatar.jpg',
+          width: 100,
+          height: 100,
+        },
+      },
+      tags: [],
+      content: '<p>Content</p>',
+      relatedPosts: [],
+    });
+
+    expect(jsonLd['@type']).toBe('BlogPosting');
+    expect(jsonLd.url).toBe('https://example.com/blog/my-post');
+    expect(jsonLd.publisher.name).toBe('rymlab');
+  });
+
+  it('builds BreadcrumbList JSON-LD with ordered items', () => {
+    const jsonLd = buildBreadcrumbJsonLd([
+      { name: 'Home', url: 'https://example.com/' },
+      { name: 'Blog', url: 'https://example.com/blog' },
+    ]);
+
+    expect(jsonLd['@type']).toBe('BreadcrumbList');
+    expect(jsonLd.itemListElement[0].position).toBe(1);
+    expect(jsonLd.itemListElement[1].name).toBe('Blog');
+  });
+
+  it('serializes JSON-LD to string', () => {
+    const data = { '@type': 'Test' };
+    expect(serializeJsonLd(data)).toBe(JSON.stringify(data));
+  });
+});


### PR DESCRIPTION
<!-- 日本語で記述して -->
This pull request introduces significant improvements to SEO, metadata, and content discoverability across the blog application. The changes standardize the use of `slug` instead of `id` for blog post URLs, add Open Graph and Twitter metadata, generate structured data for search engines, and implement dynamic routes for RSS, sitemap, robots.txt, and Open Graph images. These updates enhance the site's visibility, sharing experience, and maintainability.

**SEO and Metadata Enhancements:**

* Centralized site metadata (title, description, Open Graph, Twitter cards, canonical URLs) using new helpers from `@/lib/seo`, and added structured data (`ld+json`) for homepage, blog, and individual posts (`src/app/layout.tsx`, `src/app/blog/page.tsx`, `src/app/blog/[slug]/page.tsx`)

**Routing and Discoverability:**

* Implemented dynamic RSS feed, sitemap, and robots.txt endpoints to improve content discoverability and search engine indexing (`src/app/feed.xml/route.ts`, `src/app/sitemap.ts`, `src/app/robots.ts`)

**URL and Data Model Standardization:**

* Refactored blog post routing and components to use `slug` instead of `id` for URLs and keys, ensuring consistency and better SEO (`src/app/blog/[slug]/page.tsx` and related components)
**Codebase Cleanup:**

* Removed the now-unused `getPostById` function and related imports from `@/lib/cms`, as all references have been migrated to use `slug`.

These changes collectively modernize the blog's infrastructure for SEO, sharing, and maintainability.